### PR TITLE
Added import error handling

### DIFF
--- a/initneo4j.sh
+++ b/initneo4j.sh
@@ -10,6 +10,10 @@ then
     if [ -d /initneo4j/ ];
     then
         shopt -s nullglob
+        # If import was failed we have to remove incorrectly created "data/graph.db" directory,
+        # since Kubernetes restarts containers on failure and second start with non-empty
+        # "data/graph.db" directory will be recognized as successful.
+        trap 'echo "Import failed, removing the "data/graph.db" directory"; rm -rf "data/graph.db"' ERR
         for f in /initneo4j/*.sh;
         do
                 chmod +x "$f"
@@ -27,6 +31,8 @@ then
         do
             ./bin/neo4j-shell -path data/graph.db -file ${f}
         done
+        # Unset trap defined above
+        trap - ERR
     fi
 fi
 exec /docker-entrypoint.sh $@


### PR DESCRIPTION
If import was failed we have to remove incorrectly created "data/graph.db" directory. In kubernetes world it restarts containers on failure and second start with non-empty "data/graph.db" directory will be recognized as successful.
